### PR TITLE
Fix button link items from Google Lighthouse audit

### DIFF
--- a/src/components/ContactUs.js
+++ b/src/components/ContactUs.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { css } from 'react-emotion'
-import { RVBox, RVInput, RVGrid, RVText, RVButton, RVIcon } from 'components'
+import { RVBox, RVInput, RVGrid, RVText, RVLink, RVButton, RVIcon } from 'components'
 
 const styles = {
   inputGridWrapper: css({ gridGap: 0 }),
@@ -22,12 +22,11 @@ const ContactUs = () => (
       </RVText>
       <RVBox flex>
         {icons.map(({ icon, link }) => (
-          <RVIcon
-            key={icon}
-            href={link}
-            fontAwesomeIcon={{ icon: ['fab', icon], size: '3x' }}
-            m2
-          />
+          <RVLink href={link} m2 key={icon} aria-label={icon}>
+            <RVIcon
+              fontAwesomeIcon={{ icon: ['fab', icon], size: '3x' }}
+            />
+          </RVLink>
         ))}
       </RVBox>
     </div>

--- a/src/components/EventDetails.js
+++ b/src/components/EventDetails.js
@@ -59,8 +59,13 @@ const EventDetails = ({
         className={styles.eventSubheadingWrapperGrid}
         mb1
       >
-        <RVIcon href={gMapsLink} fontAwesomeIcon={{ icon: faMapMarker }} />
-        <RVLink href={gMapsLink} target="_blank" rel="noopener noreferrer">
+        <RVLink href={gMapsLink}>
+          <RVIcon
+            fontAwesomeIcon={{ icon: faMapMarker }}
+            aria-label="View on Google Maps"
+          />
+        </RVLink>
+        <RVLink href={gMapsLink}>
           <RVText>
             {venueName} {venueAddress}
           </RVText>
@@ -70,6 +75,7 @@ const EventDetails = ({
             icon: faCalendar,
             className: styles.eventDate,
           }}
+          aria-label="Date"
         />
         <RVText className={styles.eventDate}>
           {moment(startDate).format('dddd, MMM Do, Y')}{' '}

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { css } from 'react-emotion'
-import { RVBox, RVLink, RVText, RVGrid, RVIcon } from 'components'
+import { RVBox, RVLink, RVText, RVGrid } from 'components'
 import { Colors } from 'styles'
 
 const grey = Colors.grey.calc(80)

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -101,7 +101,6 @@ const Hero = ({ sponsors, ...otherProps }) => {
               <RVLink href="https://slackrv.now.sh">
                 <RVButton halo decorative>
                   <RVIcon
-                    key={'slack'}
                     mr1
                     flex
                     fontAwesomeIcon={{

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -131,6 +131,7 @@ const Hero = ({ sponsors, ...otherProps }) => {
                     <Img
                       fixed={sponsor.node.companyLogoDark.hero}
                       className={styles.sponsor}
+                      alt={sponsor.node.companyName}
                     />
                   )}
                 </RVBox>

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -60,7 +60,7 @@ const styles = {
 
 const Overlay = styled.div(styles.overlay)
 
-const Hero = ({ onClickCTA, sponsors, ...otherProps }) => {
+const Hero = ({ sponsors, ...otherProps }) => {
   return (
     <RVBox tag="section" {...otherProps}>
       <Overlay>
@@ -93,22 +93,26 @@ const Hero = ({ onClickCTA, sponsors, ...otherProps }) => {
               ]}
               mb8
             >
-              <RVButton onClick={onClickCTA} halo>
-                Upcoming Meetup
-              </RVButton>
-              <RVButton halo link="https://slackrv.now.sh">
-                <RVIcon
-                  key={'slack'}
-                  mr1
-                  flex
-                  fontAwesomeIcon={{
-                    icon: ['fab', 'slack'],
-                    size: '1x',
-                    color: 'white',
-                  }}
-                />
-                Join Slack
-              </RVButton>
+              <RVLink navigate="/#events">
+                <RVButton halo decorative>
+                  Upcoming Meetup
+                </RVButton>
+              </RVLink>
+              <RVLink href="https://slackrv.now.sh">
+                <RVButton halo decorative>
+                  <RVIcon
+                    key={'slack'}
+                    mr1
+                    flex
+                    fontAwesomeIcon={{
+                      icon: ['fab', 'slack'],
+                      size: '1x',
+                      color: 'white',
+                    }}
+                  />
+                  Join Slack
+                </RVButton>
+              </RVLink>
             </RVGrid>
             <RVText className={styles.sponsoredby} mb1>
               Sponsored by
@@ -138,9 +142,6 @@ const Hero = ({ onClickCTA, sponsors, ...otherProps }) => {
       </Overlay>
     </RVBox>
   )
-}
-Hero.propTypes = {
-  onClickCTA: PropTypes.func.isRequired,
 }
 
 export default styled(Hero)(styles.hero)

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -66,7 +66,7 @@ const Nav = ({ siteTitle, className }) => (
       <NavLink navigate="/speakers">Speakers</NavLink>
       {/* <NavLink navigate="/jobs">Jobs</NavLink> */}
       <NavLink navigate="/#contact-us">
-        <RVButton>Get Involved</RVButton>
+        <RVButton decorative>Get Involved</RVButton>
       </NavLink>
     </RVBox>
   </RVBox>

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -30,18 +30,18 @@ const styles = {
     }),
 }
 
-const NavLogo = ({ navigate, title }) => (
-  <RVLogo inline itemsCenter navigate={navigate} title={title} />
+const NavLogo = ({ title, to }) => (
+  <RVLogo inline itemsCenter title={title} to={to} />
 )
-const NavLink = ({ navigate, children }) => (
+const NavLink = ({ children, ...otherProps }) => (
   <RVLink
     pl2
     inline
     itemsCenter
-    navigate={navigate}
     activeStyle={{
       color: darken(0.2, Colors.theme.primary),
     }}
+    {...otherProps}
   >
     {children}
   </RVLink>
@@ -58,13 +58,13 @@ const Nav = ({ siteTitle, className }) => (
     className={className}
   >
     <section>
-      <NavLogo title={siteTitle} navigate="/" />
+      <NavLogo title={siteTitle} to="/" />
     </section>
     <RVBox tag="nav" flex itemsStretch>
-      <NavLink navigate="/events">Events</NavLink>
-      <NavLink navigate="/photos">Photos</NavLink>
-      <NavLink navigate="/speakers">Speakers</NavLink>
-      {/* <NavLink navigate="/jobs">Jobs</NavLink> */}
+      <NavLink to="/events">Events</NavLink>
+      <NavLink to="/photos">Photos</NavLink>
+      <NavLink to="/speakers">Speakers</NavLink>
+      {/* <NavLink to="/jobs">Jobs</NavLink> */}
       <NavLink navigate="/#contact-us">
         <RVButton decorative>Get Involved</RVButton>
       </NavLink>

--- a/src/components/RVButton.js
+++ b/src/components/RVButton.js
@@ -5,32 +5,29 @@ import { RVBox } from 'components'
 import { Buttons } from 'styles'
 import { injectStyles } from 'utils'
 
-function openInNewTab(url) {
-  const win = window.open(url, '_blank')
-  win.focus()
-}
-
-const RVButton = ({ className: classNameProp, link, ...otherProps }) => {
+const RVButton = ({ className: classNameProp, decorative, tag, type, ...otherProps }) => {
   const className = classNames(Buttons.base, Buttons.medium, classNameProp)
 
   return (
     <RVBox
       className={className}
+      tag={ decorative ? 'div' : tag }
+      type={ decorative ? null : type }
       {...otherProps}
-      {...(link ? { onClick: () => openInNewTab(link) } : null)}
     />
   )
 }
 
 RVButton.propTypes = {
   tag: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
-  link: PropTypes.string,
+  type: PropTypes.string,
+  decorative: PropTypes.bool.isRequired,
 }
 
 RVButton.defaultProps = {
   tag: 'button',
   type: 'button',
+  decorative: false,
 }
 
 export default injectStyles(Buttons)(RVButton)

--- a/src/components/RVIcon.js
+++ b/src/components/RVIcon.js
@@ -9,7 +9,7 @@ library.add(fab)
 
 const RVIcon = ({ fontAwesomeIcon, ...otherProps }) => {
   return (
-    <RVBox tag="a" target="_blank" rel="noopener noreferrer" {...otherProps}>
+    <RVBox tag="div" {...otherProps}>
       <FontAwesomeIcon {...fontAwesomeIcon} />
     </RVBox>
   )

--- a/src/components/RVLink.js
+++ b/src/components/RVLink.js
@@ -29,11 +29,23 @@ const RVLink = ({
       </RVBox>
     )
   }
+  if (navigate) {
+    return (
+      <RVBox {...otherProps}>
+        <Link
+          className={className}
+          to={navigate}
+        >
+          {children}
+        </Link>
+      </RVBox>
+    )
+  }
   return (
     <RVBox {...otherProps}>
       <Link
         className={className}
-        to={to || navigate}
+        to={to}
         activeStyle={activeStyle}
         activeClassName={activeClassName}
       >

--- a/src/components/RVLogo.js
+++ b/src/components/RVLogo.js
@@ -5,9 +5,9 @@ import styled from 'react-emotion'
 import { RVText } from 'components'
 import { Typography } from 'styles'
 
-const RVLogo = ({ className, to, navigate, ...otherProps }) => (
+const RVLogo = ({ className, to, ...otherProps }) => (
   <RVText subheading style={{ margin: 0 }} {...otherProps}>
-    <Link className={className} to={to || navigate}>
+    <Link className={className} to={to}>
       React Vancouver
     </Link>
   </RVText>

--- a/src/components/Sponsors.js
+++ b/src/components/Sponsors.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Img from 'gatsby-image'
 import PropTypes from 'prop-types'
-import { RVContainer, RVBox, RVText, RVButton } from 'components'
+import { RVContainer, RVBox, RVText, RVLink, RVButton } from 'components'
 import { Layout, Colors } from 'styles'
 
 const Sponsors = ({ sponsors, ...otherProps }) => (
@@ -18,19 +18,18 @@ const Sponsors = ({ sponsors, ...otherProps }) => (
               return (
                 <RVBox
                   key={sponsor.id}
-                  tag="a"
-                  href={sponsor.companyUrl}
-                  target="_blank"
                   mr2
                 >
-                  {sponsor.companyLogoDark ? (
-                    <Img
-                      fixed={sponsor.companyLogoDark.fixed}
-                      alt={sponsor.companyName}
-                    />
-                  ) : (
-                    sponsor.companyName
-                  )}
+                  <RVLink href={sponsor.companyUrl}>
+                    {sponsor.companyLogoDark ? (
+                      <Img
+                        fixed={sponsor.companyLogoDark.fixed}
+                        alt={sponsor.companyName}
+                      />
+                    ) : (
+                      sponsor.companyName
+                    )}
+                  </RVLink>
                 </RVBox>
               )
             })

--- a/src/components/Sponsors.js
+++ b/src/components/Sponsors.js
@@ -24,7 +24,10 @@ const Sponsors = ({ sponsors, ...otherProps }) => (
                   mr2
                 >
                   {sponsor.companyLogoDark ? (
-                    <Img fixed={sponsor.companyLogoDark.fixed} />
+                    <Img
+                      fixed={sponsor.companyLogoDark.fixed}
+                      alt={sponsor.companyName}
+                    />
                   ) : (
                     sponsor.companyName
                   )}

--- a/src/components/Sponsors.js
+++ b/src/components/Sponsors.js
@@ -36,9 +36,9 @@ const Sponsors = ({ sponsors, ...otherProps }) => (
           )}
         </RVBox>
 
-        {/* <RVButton link="https://reactvancouver.typeform.com/to/D7KXgd">
-          Become a Sponsor
-        </RVButton> */}
+        {/* <RVLink href="https://reactvancouver.typeform.com/to/D7KXgd">
+          <RVButton decorative>Become a Sponsor</RVButton>
+        </RVLink> */}
       </RVBox>
     </RVContainer>
   </RVBox>

--- a/src/components/Talk.js
+++ b/src/components/Talk.js
@@ -32,21 +32,27 @@ const SpeakerSummary = ({
       </RVText>
       <RVBox flex>
         {githubLink && (
-          <RVIcon
-            href={githubLink}
-            fontAwesomeIcon={{
-              icon: ['fab', 'github'],
-            }}
-            mr1
-          />
+          <RVLink href={githubLink}>
+            <RVIcon
+              fontAwesomeIcon={{
+                icon: ['fab', 'github'],
+              }}
+              mr1
+              aria-label={`${firstName}'s GitHub profile`}
+            />
+          </RVLink>
         )}
+
         {linkedInLink && (
-          <RVIcon
-            href={linkedInLink}
-            fontAwesomeIcon={{
-              icon: ['fab', 'linkedin'],
-            }}
-          />
+          <RVLink href={linkedInLink}>
+            <RVIcon
+              fontAwesomeIcon={{
+                icon: ['fab', 'linkedin'],
+              }}
+              mr1
+              aria-label={`${firstName}'s LinkedIn profile`}
+            />
+          </RVLink>
         )}
       </RVBox>
     </RVBox>

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -12,6 +12,7 @@ import {
   RVGrid,
   RVIcon,
   RVText,
+  RVLink,
   EventDetails,
 } from 'components'
 import Layout from 'layouts'
@@ -49,9 +50,9 @@ class Events extends React.Component {
 
   _renderEventListItem = ({ id, slug, startDate }) => (
     <li key={id}>
-      <Link to={`/event/${slug}`}>
+      <RVLink navigate={`/event/${slug}`}>
         {moment(startDate).format('MMMM Do, Y')}
-      </Link>
+      </RVLink>
     </li>
   )
 
@@ -111,9 +112,9 @@ class Events extends React.Component {
           <RVBox grey radius alignCenter p3 my4>
             <RVText subheading>Have an idea for a talk?</RVText>
             <RVBox my3>
-              <Link to="/#contact-us">
+              <RVLink navigate="/#contact-us">
                 <RVButton decorative>Reach Out</RVButton>
-              </Link>
+              </RVLink>
             </RVBox>
             <RVText>
               We are always looking for presenters with interesting ideas,

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -112,7 +112,7 @@ class Events extends React.Component {
             <RVText subheading>Have an idea for a talk?</RVText>
             <RVBox my3>
               <Link to="/#contact-us">
-                <RVButton>Reach Out</RVButton>
+                <RVButton decorative>Reach Out</RVButton>
               </Link>
             </RVBox>
             <RVText>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -157,9 +157,9 @@ export default class IndexPage extends React.Component {
             id="events"
             my4
           >
-            {upcomingEvent.node.title && (
+            {pastEvents[0].node.title && (
               <RVCard p3>
-                <EventDetails {...upcomingEvent.node} />
+                <EventDetails {...pastEvents[0].node} />
               </RVCard>
             )}
             <RVCard p3>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,6 +7,7 @@ import {
   Hero,
   RVBox,
   RVButton,
+  RVLink,
   RVCard,
   RVContainer,
   RVGrid,
@@ -169,9 +170,9 @@ export default class IndexPage extends React.Component {
                 if (index >= eventListLimit) return null
 
                 return (
-                  <Link to={`/event/${event.slug}`} key={event.id}>
+                  <RVLink navigate={`/event/${event.slug}`} key={event.id}>
                     <RVText mb1>{event.title}</RVText>
-                  </Link>
+                  </RVLink>
                 )
               })}
             </RVCard>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -76,10 +76,6 @@ function getOldestEvent(events) {
 }
 
 export default class IndexPage extends React.Component {
-  scrollToEvents = () => {
-    this.eventsWrapper.scrollIntoView({ behavior: 'smooth' })
-  }
-
   _renderStats = ({ talks, pastEvents }) => {
     const talksCount = getTalksCount(talks)
     const oldestEvent = getOldestEvent(pastEvents)
@@ -147,7 +143,7 @@ export default class IndexPage extends React.Component {
         description="React Vancouver is a community of developers, designers, marketers and entrepreneurs that are passionate about React."
         keywords="react, vancouver, events, developers, frontend, development, frameworks"
       >
-        <Hero onClickCTA={this.scrollToEvents} sponsors={sponsors} />
+        <Hero sponsors={sponsors} />
 
         {/* STATS */}
 
@@ -158,7 +154,7 @@ export default class IndexPage extends React.Component {
         <RVContainer>
           <RVGrid
             gridTemplateColumns={['repeat(1,1fr)', '2fr 1fr', '2fr 1fr']}
-            boxRef={node => (this.eventsWrapper = node)}
+            id="events"
             my4
           >
             {upcomingEvent.node.title && (
@@ -205,7 +201,7 @@ export default class IndexPage extends React.Component {
             </RVGrid>
             <RVBox alignCenter>
               <Link to="/speakers">
-                <RVButton>Discover All Speakers</RVButton>
+                <RVButton decorative>Discover All Speakers</RVButton>
               </Link>
             </RVBox>
           </RVBox>

--- a/src/pages/jobs.js
+++ b/src/pages/jobs.js
@@ -25,7 +25,7 @@ function getActiveJobs(jobs) {
 }
 
 const Job = ({ slug, title, companyName, logo, startDate }) => (
-  <Link to={`/job/${slug}`}>
+  <RVLink navigate={`/job/${slug}`}>
     <RVCard mb2 px3 pt2 pb3>
       <RVGrid
         gridTemplateColumns={[
@@ -48,7 +48,7 @@ const Job = ({ slug, title, companyName, logo, startDate }) => (
         </RVBox>
       </RVGrid>
     </RVCard>
-  </Link>
+  </RVLink>
 )
 
 Job.propTypes = {

--- a/src/pages/sponsors.js
+++ b/src/pages/sponsors.js
@@ -7,9 +7,9 @@ import Layout from 'layouts'
 
 const Sponsor = ({ id, companyName, companyLogoDark }) => {
   return (
-    <Link to={`/sponsor/${id}`}>
+    <RVLink navigate={`/sponsor/${id}`}>
       {companyLogoDark ? <Img {...companyLogoDark} /> : <h3>{companyName}</h3>}
-    </Link>
+    </RVLink>
   )
 }
 

--- a/src/pages/sponsors.js
+++ b/src/pages/sponsors.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 import PropTypes from 'prop-types'
+import { RVLink } from 'components'
 import Link from 'gatsby-link'
 import Img from 'gatsby-image'
 import Layout from 'layouts'

--- a/src/pages/talks.js
+++ b/src/pages/talks.js
@@ -3,11 +3,12 @@ import { graphql } from 'gatsby'
 import PropTypes from 'prop-types'
 import Link from 'gatsby-link'
 import Layout from 'layouts'
+import { RVLink } from 'components'
 
 const Talk = ({ id, title }) => (
-  <Link to={`/talk/${id}`}>
+  <RVLink navigate={`/talk/${id}`}>
     <h3>{title}</h3>
-  </Link>
+  </RVLink>
 )
 
 const Talks = ({ data }) => {

--- a/src/styles/Buttons.js
+++ b/src/styles/Buttons.js
@@ -1,9 +1,21 @@
 import { css } from 'react-emotion'
 import Layout from './Layout'
+import Typography from './Typography'
 import Colors from './Colors'
 import Shadows from './Shadows'
 
 export const base = css({
+  appearance: 'none',
+  fontSize: Layout.calcSpace(2),
+  textTransform: 'uppercase',
+  letterSpacing: '0.1rem',
+  webkitFontSmoothing: 'antialiased',
+  fontWeight: Typography.font.weight.bold,
+  lineHeight: 1,
+  padding: `${Layout.calcSpace(2)} ${Layout.calcSpace(4)}`,
+  textDecoration: 'none',
+  verticalAlign: 'middle',
+  whiteSpace: 'nowrap',
   margin: 0,
   display: 'inline-flex',
   justifyContent: 'center',

--- a/src/styles/Global.js
+++ b/src/styles/Global.js
@@ -88,7 +88,6 @@ injectGlobal`
     line-height: 1;
     padding: ${Layout.calcSpace(2)} ${Layout.calcSpace(4)};
     text-decoration: none;
-    user-select: none;
     vertical-align: middle;
     white-space: nowrap;
   }
@@ -98,7 +97,7 @@ injectGlobal`
       color: ${Colors.grey.calc(70)};
       background: transparent;
     }
-}
+  }
 
   input:-webkit-autofill {
     -webkit-animation-name: autofill;

--- a/src/templates/event.js
+++ b/src/templates/event.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import {
   RVText,
   RVBox,
+  RVLink,
   RVAvatar,
   RVCard,
   RVIcon,
@@ -43,21 +44,27 @@ const _renderTalk = talk => (
             </RVText>
             <RVBox flex>
               {speaker.githubLink && (
-                <RVIcon
-                  href={speaker.githubLink}
-                  fontAwesomeIcon={{
-                    icon: ['fab', 'github'],
-                  }}
-                  mr1
-                />
+                <RVLink href={speaker.githubLink}>
+                  <RVIcon
+                    fontAwesomeIcon={{
+                      icon: ['fab', 'github'],
+                    }}
+                    mr1
+                    aria-label={`${speaker.firstName}'s GitHub profile`}
+                  />
+                </RVLink>
               )}
+
               {speaker.linkedInLink && (
-                <RVIcon
-                  href={speaker.linkedInLink}
-                  fontAwesomeIcon={{
-                    icon: ['fab', 'linkedin'],
-                  }}
-                />
+                <RVLink href={speaker.linkedInLink}>
+                  <RVIcon
+                    fontAwesomeIcon={{
+                      icon: ['fab', 'linkedin'],
+                    }}
+                    mr1
+                    aria-label={`${speaker.firstName}'s LinkedIn profile`}
+                  />
+                </RVLink>
               )}
             </RVBox>
           </RVBox>

--- a/src/templates/event.js
+++ b/src/templates/event.js
@@ -87,11 +87,11 @@ const _renderEventLink = ({ event, textProps, label }) => {
   if (!event) return <div />
 
   return (
-    <Link to={`/event/${event.node.slug}`}>
+    <RVLink navigate={`/event/${event.node.slug}`}>
       <RVText {...textProps}>
         {label}: {event.node.title}
       </RVText>
-    </Link>
+    </RVLink>
   )
 }
 

--- a/src/templates/job.js
+++ b/src/templates/job.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import PropTypes from 'prop-types'
 import Layout from 'layouts'
-import { RVBox, RVText, RVContainer } from 'components'
+import { RVBox, RVText, RVLink, RVContainer } from 'components'
 
 const JobTemplate = ({ data }) => {
   const job = data.contentfulJobs
@@ -23,13 +23,9 @@ const JobTemplate = ({ data }) => {
             }}
           />
           {urlToJobApplication && (
-            <a
-              href={urlToJobApplication}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <RVLink href={urlToJobApplication}>
               See Official Posting
-            </a>
+            </RVLink>
           )}
         </RVBox>
       </RVContainer>


### PR DESCRIPTION
Fixes the button and link issues from #11:
- "Get involved" in the header is actually a <button> in a <a>. The text in the button can stay, but the button shouldn't be there. "Discover speakers" has the same issue.
- Slack and Meetup linked icons missing screenreader text
- AxiomZen linked logo image missing alt text (should be AxiomZen)
- Add rel="noopener" or rel="noreferrer" to any external links (the AxiomZen link)