### PR TITLE
Some a11y improvements

### DIFF
--- a/src/components/ContactUs.js
+++ b/src/components/ContactUs.js
@@ -17,7 +17,7 @@ const ContactUs = () => (
       <RVText heading mb1>
         Email Us
       </RVText>
-      <RVText subheading mb1>
+      <RVText subheading mb1 tag="a" href="mailto:admin@reactvancouver.com">
         admin@reactvancouver.com
       </RVText>
       <RVBox flex>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -3,7 +3,7 @@ import { css } from 'react-emotion'
 import { RVBox, RVLink, RVText, RVGrid, RVIcon } from 'components'
 import { Colors } from 'styles'
 
-const grey = Colors.grey.calc(80)
+const grey = Colors.grey.calc(50)
 
 const styles = {
   text: css({

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -3,13 +3,11 @@ import { css } from 'react-emotion'
 import { RVBox, RVLink, RVText, RVGrid, RVIcon } from 'components'
 import { Colors } from 'styles'
 
-const grey = Colors.grey.calc(50)
-
 const styles = {
   text: css({
-    color: grey,
+    color: Colors.grey.medium,
     a: {
-      color: grey,
+      color: Colors.grey.medium,
       textDecoration: 'underline',
     },
   }),

--- a/src/components/Speaker.js
+++ b/src/components/Speaker.js
@@ -38,11 +38,11 @@ const _renderTalks = talks => {
 }
 
 const _renderTalk = ({ id, title, date }) => {
-  const formatedDate = date ? moment(date).format('MMM Do, Y') : 'Unknown'
+  const formattedDate = date ? moment(date).format('MMM Do, Y') : 'Unknown'
 
   return (
     <RVBox key={id} className={styles.talkBox}>
-      <RVBadge className={styles.talkDateBadge}>{formatedDate}</RVBadge>
+      <RVText className={styles.dateText}>{formattedDate}</RVText>
       <RVText className={styles.titleText}>{title}</RVText>
     </RVBox>
   )
@@ -68,14 +68,10 @@ const styles = {
     minHeight: 88,
     marginBottom: 8,
   }),
-  talkDateBadge: css({
-    marginTop: 0,
-    marginBottom: 8,
-    height: 32,
-    fontSize: 12,
-    minWidth: 105,
-    textAlign: 'center',
-    marginRight: 8,
+  dateText: css({
+    marginBottom: 6,
+    color: Colors.grey.medium,
+    fontWeight: Typography.font.weight.bold,
   }),
   titleText: {
     minHeight: 48,

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -41,6 +41,7 @@ const Layout = ({
         },
       ]}
     >
+      <html lang="en" />
       <link
         href="https://fonts.googleapis.com/css?family=Nunito:400,700,900"
         rel="stylesheet"

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -18,7 +18,6 @@ import Layout from 'layouts'
 
 const styles = {
   list: {
-    listStyle: 'none',
     minWidth: 200,
   },
 }
@@ -48,11 +47,9 @@ class Events extends React.Component {
   }
 
   _renderEventListItem = ({ id, slug, startDate }) => (
-    <li key={id}>
-      <Link to={`/event/${slug}`}>
-        {moment(startDate).format('MMMM Do, Y')}
-      </Link>
-    </li>
+    <Link to={`/event/${slug}`} key={id}>
+      <RVText mb1>{moment(startDate).format('MMMM Do, Y')}</RVText>
+    </Link>
   )
 
   render() {

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -78,7 +78,7 @@ class Events extends React.Component {
             ]}
           >
             <RVBox tag="ul" style={styles.list}>
-              <RVText subheading>Upcoming Events</RVText>
+              <RVText subheading mb2>Upcoming Events</RVText>
               {upcomingEvents.length > 0 ? (
                 upcomingEvents.map(({ node }) => {
                   return this._renderEventListItem({ ...node })
@@ -86,27 +86,31 @@ class Events extends React.Component {
               ) : (
                 <RVText>No Upcoming Events</RVText>
               )}
-              <RVText subheading>Past Events</RVText>
+
+              <RVText subheading mb2 mt3>Past Events</RVText>
               {pastEvents.map(({ node }, index) => {
                 if (!seeAllEvents && index >= 4) {
                   return null
                 }
                 return this._renderEventListItem({ ...node })
               })}
-              <RVButton onClick={this.toggleEventsList}>
+
+              <RVButton onClick={this.toggleEventsList} mt3>
                 {seeAllEvents ? 'Shorten List' : 'Show All'}
               </RVButton>
             </RVBox>
 
-            <RVCard px3 py2>
-              {event ? (
+            {event ? (
+              <RVCard px3 py2>
                 <EventDetails {...event.node} />
-              ) : (
-                <RVText alignCenter label>
+              </RVCard>
+            ) : (
+              <RVCard px3 py2 flex center itemsCenter>
+                <RVText label>
                   No upcoming events
                 </RVText>
-              )}
-            </RVCard>
+              </RVCard>
+            )}
           </RVGrid>
           <RVBox grey radius alignCenter p3 my4>
             <RVText subheading>Have an idea for a talk?</RVText>

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -77,7 +77,7 @@ class Events extends React.Component {
               'min-content 1fr',
             ]}
           >
-            <RVBox tag="ul" style={styles.list}>
+            <RVBox style={styles.list}>
               <RVText subheading mb2>Upcoming Events</RVText>
               {upcomingEvents.length > 0 ? (
                 upcomingEvents.map(({ node }) => {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -203,7 +203,7 @@ export default class IndexPage extends React.Component {
                 />
               ))}
             </RVGrid>
-            <RVBox alignCenter mt4>
+            <RVBox alignCenter mt3>
               <Link to="/speakers">
                 <RVButton>Discover All Speakers</RVButton>
               </Link>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -203,7 +203,7 @@ export default class IndexPage extends React.Component {
                 />
               ))}
             </RVGrid>
-            <RVBox alignCenter>
+            <RVBox alignCenter mt4>
               <Link to="/speakers">
                 <RVButton>Discover All Speakers</RVButton>
               </Link>

--- a/src/styles/Buttons.js
+++ b/src/styles/Buttons.js
@@ -14,7 +14,6 @@ export const base = css({
   borderColor: Colors.theme.primary,
   background: Colors.theme.primary,
   color: Colors.grey.white,
-  outline: 'none',
 })
 
 export const outline = css({
@@ -29,7 +28,6 @@ export const link = css({
   color: Colors.theme.primary,
   fontStyle: 'italic',
   textTransform: 'none',
-  outline: 'none',
 })
 
 export const halo = css({

--- a/src/styles/Colors.js
+++ b/src/styles/Colors.js
@@ -13,7 +13,7 @@ export const grey = {
   // TODO: Review this color.
   lightDark: '#EBEDEF',
   dark: calcGrey(30),
-  medium: calcGrey(60),
+  medium: calcGrey(50),
   light: calcGrey(98),
   white: '#FFFFFF',
   calc: calcGrey,


### PR DESCRIPTION
Accessibility fixes, mostly things for caught from automated scans, including some from #11.

- Improve some colour contrast, especially credit text at the bottom of the site has insufficient contrast
- `<html>` missing `lang` attribute
- Fix elements other than `<li>` in `<ul>`
- Don't remove outline styles on links and buttons (better to add more prominent hover/focus styles, though)
- Adjust some spacing
- Don't use badges because they're styled like buttons
- Made email address a link